### PR TITLE
Refactor Nextflow scripts to DSL2 style, standardize channels and process resource config, and update env versions

### DIFF
--- a/L26_nextflow-intro/exercise_channels/factories.nf
+++ b/L26_nextflow-intro/exercise_channels/factories.nf
@@ -1,9 +1,11 @@
-def letters = ['A', 'B', 'C']
+workflow {
+    def letters = ['A', 'B', 'C']
 
+    channel
+        .fromList(letters)
+        .view()
 
-Channel.fromList(letters)
-.view()
-
-
-Channel.value(letters)
-.view()
+    channel
+        .value(letters)
+        .view()
+}

--- a/L26_nextflow-intro/exercise_channels/pairs.nf
+++ b/L26_nextflow-intro/exercise_channels/pairs.nf
@@ -1,2 +1,5 @@
-ch_files = Channel.fromFilePairs("./files/*_{1,2}.txt")
-ch_files.view{ "value: $it"}
+workflow {
+    channel
+        .fromFilePairs('./files/*_{1,2}.txt')
+        .view { "value: $it" }
+}

--- a/L26_nextflow-intro/hello.nf
+++ b/L26_nextflow-intro/hello.nf
@@ -1,36 +1,36 @@
 #!/usr/bin/env nextflow
 
-params.greeting = 'Hello world!' 
-greeting_ch = Channel.of(params.greeting) 
+params.greeting = 'Hello world!'
 
-process SPLITLETTERS { 
-    input: 
-    val x 
+process SPLITLETTERS {
+    input:
+    val x
 
-    output: 
-    path 'chunk_*' 
+    output:
+    path 'chunk_*'
 
-    script: 
+    script:
     """
     printf '$x' | split -b 6 - chunk_
     """
-} 
+}
 
-process CONVERTTOUPPER { 
-    input: 
-    path y 
+process CONVERTTOUPPER {
+    input:
+    path y
 
-    output: 
-    stdout 
+    output:
+    stdout
 
-    script: 
+    script:
     """
     cat $y | tr '[a-z]' '[A-Z]'
     """
-} 
+}
 
-workflow { 
-    letters_ch = SPLITLETTERS(greeting_ch) 
-    results_ch = CONVERTTOUPPER(letters_ch.flatten()) 
-    results_ch.view { it } 
-} 
+workflow {
+    def greeting_ch = channel.of(params.greeting)
+    def letters_ch = SPLITLETTERS(greeting_ch)
+    def results_ch = CONVERTTOUPPER(letters_ch.flatten())
+    results_ch.view { it }
+}

--- a/L26_nextflow-intro/nextflow_environment.yml
+++ b/L26_nextflow-intro/nextflow_environment.yml
@@ -3,7 +3,7 @@ channels:
     - bioconda
     - conda-forge
 dependencies:
-    - nextflow=23.10.1
-    - nf-core=2.13.1
+    - nextflow=25.10.4
+    - nf-core=3.5.2
     - python=3.11
-    - nf-test=0.8.4
+    - nf-test=0.9.3

--- a/L27_nextflow-coding/01_exercise_processes/inputfile.nf
+++ b/L27_nextflow-coding/01_exercise_processes/inputfile.nf
@@ -1,5 +1,3 @@
-ch_input = Channel.fromPath('../files/content.txt')
-
 process headLine {
 
     input:
@@ -16,8 +14,7 @@ process headLine {
 }
 
 workflow {
-
-    results_ch = headLine( ch_input )
+    def ch_input = channel.fromPath('../files/content.txt')
+    def results_ch = headLine(ch_input)
     results_ch.view()
-
 }

--- a/L27_nextflow-coding/02_exercise_config/params.nf
+++ b/L27_nextflow-coding/02_exercise_config/params.nf
@@ -2,5 +2,7 @@
 params.foo = 'Hello'
 params.bar = 'world!'
 
-// print the both params
-println "$params.foo $params.bar"
+workflow {
+    // print both params
+    println "${params.foo} ${params.bar}"
+}

--- a/L27_nextflow-coding/03_exercise_lines/hello.nf
+++ b/L27_nextflow-coding/03_exercise_lines/hello.nf
@@ -10,6 +10,7 @@ process splitLetters {
     output:
     file 'chunk_*'
 
+    script:
     """
     printf '$x' | split -b 6 - chunk_
     """
@@ -23,18 +24,17 @@ process convertToUpper {
     output:
     stdout
 
+    script:
     """
     cat $y | tr '[a-z]' '[A-Z]'
     """
 }
 
-params.greeting  = 'Hello world!'
-greeting_ch = Channel.from(params.greeting)
+params.greeting = 'Hello world!'
 
 workflow {
-
-    letters_ch = splitLetters(greeting_ch)
-    uppercase_ch = convertToUpper( letters_ch.flatten() )
-    uppercase_ch.view{ it.trim() }
-
+    def greeting_ch = channel.of(params.greeting)
+    def letters_ch = splitLetters(greeting_ch)
+    def uppercase_ch = convertToUpper(letters_ch.flatten())
+    uppercase_ch.view { it.trim() }
 }

--- a/L27_nextflow-coding/03_exercise_lines/solution/solution_each_line.nf
+++ b/L27_nextflow-coding/03_exercise_lines/solution/solution_each_line.nf
@@ -1,7 +1,6 @@
 #!/usr/bin/env nextflow
 
-params.input  = '../files/content.txt'
-input_ch = Channel.fromPath(params.input)
+params.input = "$projectDir/../../files/content.txt"
 
 process splitLines {
 
@@ -9,7 +8,7 @@ process splitLines {
     path file
 
     output:
-    path "line_*"
+    path 'line_*'
 
     script:
     """
@@ -17,7 +16,7 @@ process splitLines {
     while read -r line
     do
         let "count+=1"
-        echo \$line >line_\$count
+        echo \$line > line_\$count
     done < $file
     """
 }
@@ -30,15 +29,15 @@ process getLast {
     output:
     stdout
 
+    script:
     """
     cat $file | awk '{print \$NF}'
     """
 }
 
 workflow {
-    single_lines_ch = splitLines( input_ch )
-    results_ch = getLast( single_lines_ch )
+    def input_ch = channel.fromPath(params.input)
+    def single_lines_ch = splitLines(input_ch)
+    def results_ch = getLast(single_lines_ch)
     results_ch.view()
 }
-
-

--- a/L28_nextflow-modules/modules/exercise_solution/solution_workflow.nf
+++ b/L28_nextflow-modules/modules/exercise_solution/solution_workflow.nf
@@ -1,12 +1,12 @@
 #!/usr/bin/env nextflow
 
-params.input = "https://raw.githubusercontent.com/lescai-teaching/class-bigdata/main/L11_data_import-export/L11_dataset_babynames.rds"
-input_ch = Channel.fromPath(params.input)
-params.outdir = "."
+params.input = 'https://raw.githubusercontent.com/lescai-teaching/class-bigdata/main/L11_data_import-export/L11_dataset_babynames.rds'
+params.outdir = '.'
 
-include { SUMMARISE } from "./solution_module.nf"
+include { SUMMARISE } from './solution_module.nf'
 
 workflow {
-	ch_rscript = Channel.value(file("$projectDir/summarise.R"))
-    SUMMARISE( input_ch, ch_rscript )
+    def input_ch = channel.fromPath(params.input)
+    def ch_rscript = channel.value(file("$projectDir/summarise.R"))
+    SUMMARISE(input_ch, ch_rscript)
 }

--- a/L28_nextflow-modules/modules/hello.nf
+++ b/L28_nextflow-modules/modules/hello.nf
@@ -1,7 +1,6 @@
 #!/usr/bin/env nextflow
 
 params.greeting = 'Hello world!'
-greeting_ch = Channel.of(params.greeting)
 
 process SPLITLETTERS {
     input:
@@ -10,6 +9,7 @@ process SPLITLETTERS {
     output:
     path 'chunk_*'
 
+    script:
     """
     printf '$x' | split -b 6 - chunk_
     """
@@ -22,13 +22,15 @@ process CONVERTTOUPPER {
     output:
     stdout
 
+    script:
     """
-    cat $y | tr '[a-z]' '[A-Z]' 
+    cat $y | tr '[a-z]' '[A-Z]'
     """
 }
 
 workflow {
-    letters_ch = SPLITLETTERS(greeting_ch)
-    results_ch = CONVERTTOUPPER(letters_ch.flatten())
-    results_ch.view{ it }
+    def greeting_ch = channel.of(params.greeting)
+    def letters_ch = SPLITLETTERS(greeting_ch)
+    def results_ch = CONVERTTOUPPER(letters_ch.flatten())
+    results_ch.view { it }
 }

--- a/L28_nextflow-modules/modules/hello2.nf
+++ b/L28_nextflow-modules/modules/hello2.nf
@@ -1,13 +1,13 @@
 #!/usr/bin/env nextflow
 
-params.greeting  = 'Hello world!'
-greeting_ch = Channel.of(params.greeting)
+params.greeting = 'Hello world!'
 
-include { SPLITLETTERS   } from './modules.nf'
+include { SPLITLETTERS } from './modules.nf'
 include { CONVERTTOUPPER } from './modules.nf'
 
-workflow{
-    letters_ch = SPLITLETTERS(greeting_ch)
-    results_ch = CONVERTTOUPPER(letters_ch.flatten())
-    results_ch.view{ it }
+workflow {
+    def greeting_ch = channel.of(params.greeting)
+    def letters_ch = SPLITLETTERS(greeting_ch)
+    def results_ch = CONVERTTOUPPER(letters_ch.flatten())
+    results_ch.view { it }
 }

--- a/L28_nextflow-modules/modules/modules.nf
+++ b/L28_nextflow-modules/modules/modules.nf
@@ -5,6 +5,7 @@ process SPLITLETTERS {
     output:
     path 'chunk_*'
 
+    script:
     """
     printf '$x' | split -b 6 - chunk_
     """
@@ -17,7 +18,8 @@ process CONVERTTOUPPER {
     output:
     stdout
 
+    script:
     """
-    cat $y | tr '[a-z]' '[A-Z]' 
+    cat $y | tr '[a-z]' '[A-Z]'
     """
 }

--- a/L28_nextflow-modules/operators/collect.nf
+++ b/L28_nextflow-modules/operators/collect.nf
@@ -1,4 +1,4 @@
-Channel
+channel
     .of(1, 2, 3, 4)
     .collect()
     .view()

--- a/L28_nextflow-modules/operators/group.nf
+++ b/L28_nextflow-modules/operators/group.nf
@@ -1,4 +1,4 @@
-Channel
+channel
     .of([1, 'A'], [1, 'B'], [2, 'C'], [3, 'B'], [1, 'C'], [2, 'A'], [3, 'D'])
     .groupTuple()
     .view()

--- a/L28_nextflow-modules/operators/group_exercise/group_solution.nf
+++ b/L28_nextflow-modules/operators/group_exercise/group_solution.nf
@@ -1,4 +1,4 @@
-Channel
+channel
     .fromPath('group_exercise/*')
     .map { file -> tuple(file.baseName, file) }
     .groupTuple()

--- a/L28_nextflow-modules/operators/map.nf
+++ b/L28_nextflow-modules/operators/map.nf
@@ -1,28 +1,26 @@
-
 // first option
 
-nums = Channel.of(1, 2, 3, 4) 
-square = nums.map { it -> it * it } 
-square.view() 
+def nums = channel.of(1, 2, 3, 4)
+def square = nums.map { it -> it * it }
+square.view()
 
 // second option to chain operators
 
-Channel
+channel
     .of(1, 2, 3, 4)
     .map { it -> it * it }
     .view()
 
 // apply any function
 
-Channel
+channel
     .of('hello', 'world')
     .map { it -> it.reverse() }
     .view()
 
 // or create new tuples
 
-Channel
+channel
     .of('hello', 'world')
     .map { word -> [word, word.size()] }
     .view { word, len -> "$word contains $len letters" }
-

--- a/L28_nextflow-modules/operators/mix.nf
+++ b/L28_nextflow-modules/operators/mix.nf
@@ -1,6 +1,6 @@
-my_channel_1 = Channel.of(1, 2, 3)
-my_channel_2 = Channel.of('a', 'b')
-my_channel_3 = Channel.of('z')
+def my_channel_1 = channel.of(1, 2, 3)
+def my_channel_2 = channel.of('a', 'b')
+def my_channel_3 = channel.of('z')
 
 my_channel_1
     .mix(my_channel_2, my_channel_3)

--- a/L29_nextflow_assembling-workflow/main.nf
+++ b/L29_nextflow_assembling-workflow/main.nf
@@ -1,16 +1,14 @@
 #!/usr/bin/env nextflow
 
-// create input channel
-input_ch = Channel.fromPath(params.input)
-
 // load modules
-include { READ_DATA    } from './modules/reading.nf'
-include { LINEARMODEL  } from './modules/linear.nf'
+include { READ_DATA } from './modules/reading.nf'
+include { LINEARMODEL } from './modules/linear.nf'
 include { RANDOMFOREST } from './modules/random.nf'
 
 // run workflow
 workflow {
-	READ_DATA( input_ch )
-	LINEARMODEL( READ_DATA.out.dataset )
-	RANDOMFOREST( READ_DATA.out.dataset )
+    def input_ch = channel.fromPath(params.input)
+    READ_DATA(input_ch)
+    LINEARMODEL(READ_DATA.out.dataset)
+    RANDOMFOREST(READ_DATA.out.dataset)
 }

--- a/L29_nextflow_assembling-workflow/modules/linear.nf
+++ b/L29_nextflow_assembling-workflow/modules/linear.nf
@@ -1,31 +1,29 @@
-
 process LINEARMODEL {
 
-    tag "linear"
-	label 'process_medium'
+    tag 'linear'
+    label 'process_medium'
 
-	cpus = params.max_cpus
-	memory = params.max_memory
+    cpus params.max_cpus
+    memory params.max_memory
 
-	publishDir "${params.outdir}/results/linear_model", mode: 'copy'
-    
-	container "${ workflow.containerEngine == 'singularity' ?
+    publishDir "${params.outdir}/results/linear_model", mode: 'copy'
+
+    container "${workflow.containerEngine == 'singularity' ?
         'library://lescailab/bigdata/bigdata-rstudio:1.4.0' :
-        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0' }"
-    
-	input:
-	path dataset
+        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0'}"
 
-	output:
-	path "*.tsv", emit: tables
-	path "*.pdf", emit: plots
+    input:
+    path dataset
 
-	script:
-	"""
+    output:
+    path '*.tsv', emit: tables
+    path '*.pdf', emit: plots
+
+    script:
+    """
     run_linear_model.R \
-	$dataset \
-	${task.cpus} \
-	"LM_results"
-	"""
-
+    $dataset \
+    ${task.cpus} \
+    "LM_results"
+    """
 }

--- a/L29_nextflow_assembling-workflow/modules/random.nf
+++ b/L29_nextflow_assembling-workflow/modules/random.nf
@@ -1,30 +1,29 @@
 process RANDOMFOREST {
 
-    tag "randomforest"
-	label 'process_medium'
+    tag 'randomforest'
+    label 'process_medium'
 
-	cpus = params.max_cpus
-	memory = params.max_memory
+    cpus params.max_cpus
+    memory params.max_memory
 
-	publishDir "${params.outdir}/results/random_forest", mode: 'copy'
-    
-	container "${ workflow.containerEngine == 'singularity' ?
+    publishDir "${params.outdir}/results/random_forest", mode: 'copy'
+
+    container "${workflow.containerEngine == 'singularity' ?
         'library://lescailab/bigdata/bigdata-rstudio:1.4.0' :
-        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0' }"
-    
-	input:
-	path dataset
+        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0'}"
 
-	output:
-	path "*.tsv", emit: tables
-	path "*.pdf", emit: plots
+    input:
+    path dataset
 
-	script:
-	"""
+    output:
+    path '*.tsv', emit: tables
+    path '*.pdf', emit: plots
+
+    script:
+    """
     run_random_forest.R \
-	$dataset \
-	${task.cpus} \
-	"RF_results"
-	"""
-
+    $dataset \
+    ${task.cpus} \
+    "RF_results"
+    """
 }

--- a/L29_nextflow_assembling-workflow/modules/reading.nf
+++ b/L29_nextflow_assembling-workflow/modules/reading.nf
@@ -1,27 +1,26 @@
 process READ_DATA {
 
-	tag "import"
-	label 'process_low'
+    tag 'import'
+    label 'process_low'
 
-	cpus   = 1
-    memory = 1.GB
+    cpus 1
+    memory 1.GB
 
-	publishDir "${params.outdir}/preprocess", mode: 'copy'
+    publishDir "${params.outdir}/preprocess", mode: 'copy'
 
-	container "${ workflow.containerEngine == 'singularity' ?
+    container "${workflow.containerEngine == 'singularity' ?
         'library://lescailab/bigdata/bigdata-rstudio:1.4.0' :
-        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0' }"
-	
-	input:
-	path tsvfile
+        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0'}"
 
-	output:
-	path "*.rds", emit: dataset
+    input:
+    path tsvfile
 
-	script:
-	"""
-	run_import.R \
-	$tsvfile
-	"""
+    output:
+    path '*.rds', emit: dataset
 
+    script:
+    """
+    run_import.R \
+    $tsvfile
+    """
 }

--- a/L29_nextflow_assembling-workflow/nextflow.config
+++ b/L29_nextflow_assembling-workflow/nextflow.config
@@ -2,6 +2,8 @@
 // base defaults
 params.input  = "https://raw.githubusercontent.com/lescai-teaching/class-bigdata/main/L29_nextflow_assembling-workflow/L29_dataset_biodegradation.tsv"
 params.outdir = "./"
+params.max_cpus   = 1
+params.max_memory = 4.GB
 
 env {
 	TZ = 'Europe/Rome' // this is needed because container doesn't have a timezone
@@ -29,7 +31,6 @@ profiles {
 	}
 	desktop {
         docker.enabled         = true
-        docker.userEmulation   = true
 		process.executor       = 'local'
 		params.max_cpus        = 1
 		params.max_memory      = 4.GB

--- a/L30_nextflow_your-workflow/solution/main.nf
+++ b/L30_nextflow_your-workflow/solution/main.nf
@@ -1,16 +1,14 @@
 #!/usr/bin/env nextflow
 
-// create input channel
-input_ch = Channel.fromPath(params.input)
-
 // load modules
-include { READ_DATA                } from './modules/reading.nf'
-include { RUNMODEL as LOGREG       } from './modules/runmodel.nf'
+include { READ_DATA } from './modules/reading.nf'
+include { RUNMODEL as LOGREG } from './modules/runmodel.nf'
 include { RUNMODEL as RANDOMFOREST } from './modules/runmodel.nf'
 
 // run workflow
 workflow {
-	READ_DATA( input_ch, "$projectDir/scripts/run_import.R " )
-	LOGREG( READ_DATA.out.dataset, "$projectDir/scripts/run_logistic_model.R", "logreg" )
-	RANDOMFOREST( READ_DATA.out.dataset, "$projectDir/scripts/run_random_forest.R", "randomforest" )
+    def input_ch = channel.fromPath(params.input)
+    READ_DATA(input_ch, "$projectDir/scripts/run_import.R")
+    LOGREG(READ_DATA.out.dataset, "$projectDir/scripts/run_logistic_model.R", 'logreg')
+    RANDOMFOREST(READ_DATA.out.dataset, "$projectDir/scripts/run_random_forest.R", 'randomforest')
 }

--- a/L30_nextflow_your-workflow/solution/modules/reading.nf
+++ b/L30_nextflow_your-workflow/solution/modules/reading.nf
@@ -1,28 +1,27 @@
 process READ_DATA {
 
-	tag "import"
-	label 'process_low'
+    tag 'import'
+    label 'process_low'
 
-	cpus   = 1
-    memory = 1.GB
+    cpus 1
+    memory 1.GB
 
-	publishDir "${params.outdir}/preprocess", mode: 'copy'
+    publishDir "${params.outdir}/preprocess", mode: 'copy'
 
-	container "${ workflow.containerEngine == 'singularity' ?
+    container "${workflow.containerEngine == 'singularity' ?
         'library://lescailab/bigdata/bigdata-rstudio:1.4.0' :
-        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0' }"
-	
-	input:
-	path tsvfile
-	path rscriptfile
+        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0'}"
 
-	output:
-	path "*.rds", emit: dataset
+    input:
+    path tsvfile
+    path rscriptfile
 
-	script:
-	"""
-	Rscript $rscriptfile \
-	$tsvfile
-	"""
+    output:
+    path '*.rds', emit: dataset
 
+    script:
+    """
+    Rscript $rscriptfile \
+    $tsvfile
+    """
 }

--- a/L30_nextflow_your-workflow/solution/modules/runmodel.nf
+++ b/L30_nextflow_your-workflow/solution/modules/runmodel.nf
@@ -1,32 +1,28 @@
-
 process RUNMODEL {
 
-    tag "run: ${modeltype}"
+    cpus params.max_cpus
+    memory params.max_memory
 
-	cpus = params.max_cpus
-	memory = params.max_memory
+    publishDir({ "${params.outdir}/results/${task.process.toLowerCase()}" }, mode: 'copy')
 
-	publishDir "${params.outdir}/results/${modeltype}", mode: 'copy'
-    
-	container "${ workflow.containerEngine == 'singularity' ?
+    container "${workflow.containerEngine == 'singularity' ?
         'library://lescailab/bigdata/bigdata-rstudio:1.4.0' :
-        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0' }"
-    
-	input:
-	path dataset
-	path rscript
-	val  modeltype
+        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0'}"
 
-	output:
-	path "*.rds", emit: model
-	path "*.pdf", emit: plots
+    input:
+    path dataset
+    path rscript
+    val modeltype
 
-	script:
-	"""
+    output:
+    path '*.rds', emit: model
+    path '*.pdf', emit: plots
+
+    script:
+    """
     Rscript $rscript \
-	$dataset \
-	${task.cpus} \
-	$modeltype
-	"""
-
+    $dataset \
+    ${task.cpus} \
+    $modeltype
+    """
 }

--- a/L30_nextflow_your-workflow/solution/nextflow.config
+++ b/L30_nextflow_your-workflow/solution/nextflow.config
@@ -36,7 +36,6 @@ profiles {
 	}
 	desktop {
         docker.enabled         = true
-        docker.userEmulation   = true
 		process.executor       = 'local'
 		params.max_cpus        = 1
 		params.max_memory      = 4.GB

--- a/L31_nextflow_more-coding/help_files/how_to_read_tsv.nf
+++ b/L31_nextflow_more-coding/help_files/how_to_read_tsv.nf
@@ -1,7 +1,4 @@
-Channel
+def input_data_ch = channel
     .fromPath(params.input)
-    .splitCsv(header:true, sep:'\t')
-    .map { row -> 
-        [row.experiment, row.datafile] 
-	}
-    .set { input_data_ch }
+    .splitCsv(header: true, sep: '\t')
+    .map { row -> [row.experiment, row.datafile] }

--- a/L31_nextflow_more-coding/solution/main.nf
+++ b/L31_nextflow_more-coding/solution/main.nf
@@ -10,28 +10,22 @@ include { SUMMARY } from './modules/summary/main'
 
 workflow {
 
-	// read the input file and load data
-	// into an input channel
-
-	Channel
+    // read the input file and load data into an input channel
+    def input_data_ch = channel
         .fromPath(params.input)
-        .splitCsv(header:true, sep:'\t')
-        .map { row -> 
-            [row.experiment, row.datafile] 
-		}
-        .set { input_data_ch }
+        .splitCsv(header: true, sep: '\t')
+        .map { row -> [row.experiment, row.datafile] }
 
     // process the input data in parallel
-	MEAN_SD(input_data_ch)
-	PC1_LOADING(input_data_ch)
-	MAD(input_data_ch)
+    MEAN_SD(input_data_ch)
+    PC1_LOADING(input_data_ch)
+    MAD(input_data_ch)
 
-	// collect the results from the previous processes
-	all_stats = MEAN_SD.out.meansd.collect { it[1]}
-	.combine(PC1_LOADING.out.pc1load.collect { it[1]})
-	.combine(MAD.out.mad.collect { it[1]})
+    // collect the results from the previous processes
+    def all_stats = MEAN_SD.out.meansd.collect { it[1] }
+        .combine(PC1_LOADING.out.pc1load.collect { it[1] })
+        .combine(MAD.out.mad.collect { it[1] })
 
-	// generate the summary
-	SUMMARY(all_stats)
-
+    // generate the summary
+    SUMMARY(all_stats)
 }

--- a/L31_nextflow_more-coding/solution/nextflow.config
+++ b/L31_nextflow_more-coding/solution/nextflow.config
@@ -60,7 +60,6 @@ profiles {
 	}
 	desktop {
         docker.enabled         = true
-        docker.userEmulation   = true
 		process.executor       = 'local'
 		params.max_cpus        = 1
 		params.max_memory      = 4.GB

--- a/L34_cloud_nextflow/pipeline/main.nf
+++ b/L34_cloud_nextflow/pipeline/main.nf
@@ -1,16 +1,14 @@
 #!/usr/bin/env nextflow
 
-// create input channel
-input_ch = Channel.fromPath(params.input)
-
 // load modules
-include { READ_DATA                } from './modules/reading.nf'
-include { RUNMODEL as LOGREG       } from './modules/runmodel.nf'
+include { READ_DATA } from './modules/reading.nf'
+include { RUNMODEL as LOGREG } from './modules/runmodel.nf'
 include { RUNMODEL as RANDOMFOREST } from './modules/runmodel.nf'
 
 // run workflow
 workflow {
-	READ_DATA( input_ch, "$projectDir/scripts/run_import.R " )
-	LOGREG( READ_DATA.out.dataset, "$projectDir/scripts/run_logistic_model.R", "logreg" )
-	RANDOMFOREST( READ_DATA.out.dataset, "$projectDir/scripts/run_random_forest.R", "randomforest" )
+    def input_ch = channel.fromPath(params.input)
+    READ_DATA(input_ch, "$projectDir/scripts/run_import.R")
+    LOGREG(READ_DATA.out.dataset, "$projectDir/scripts/run_logistic_model.R", 'logreg')
+    RANDOMFOREST(READ_DATA.out.dataset, "$projectDir/scripts/run_random_forest.R", 'randomforest')
 }

--- a/L34_cloud_nextflow/pipeline/modules/reading.nf
+++ b/L34_cloud_nextflow/pipeline/modules/reading.nf
@@ -1,28 +1,27 @@
 process READ_DATA {
 
-	tag "import"
-	label 'process_low'
+    tag 'import'
+    label 'process_low'
 
-	cpus   = 1
-    memory = 1.GB
+    cpus 1
+    memory 1.GB
 
-	publishDir "${params.outdir}/preprocess", mode: 'copy'
+    publishDir "${params.outdir}/preprocess", mode: 'copy'
 
-	container "${ workflow.containerEngine == 'singularity' ?
+    container "${workflow.containerEngine == 'singularity' ?
         'library://lescailab/bigdata/bigdata-rstudio:1.4.0' :
-        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0' }"
-	
-	input:
-	path tsvfile
-	path rscriptfile
+        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0'}"
 
-	output:
-	path "*.rds", emit: dataset
+    input:
+    path tsvfile
+    path rscriptfile
 
-	script:
-	"""
-	Rscript $rscriptfile \
-	$tsvfile
-	"""
+    output:
+    path '*.rds', emit: dataset
 
+    script:
+    """
+    Rscript $rscriptfile \
+    $tsvfile
+    """
 }

--- a/L34_cloud_nextflow/pipeline/modules/runmodel.nf
+++ b/L34_cloud_nextflow/pipeline/modules/runmodel.nf
@@ -1,32 +1,28 @@
-
 process RUNMODEL {
 
-    tag "run: ${modeltype}"
+    cpus params.max_cpus
+    memory params.max_memory
 
-	cpus = params.max_cpus
-	memory = params.max_memory
+    publishDir({ "${params.outdir}/results/${task.process.toLowerCase()}" }, mode: 'copy')
 
-	publishDir "${params.outdir}/results/${modeltype}", mode: 'copy'
-    
-	container "${ workflow.containerEngine == 'singularity' ?
+    container "${workflow.containerEngine == 'singularity' ?
         'library://lescailab/bigdata/bigdata-rstudio:1.4.0' :
-        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0' }"
-    
-	input:
-	path dataset
-	path rscript
-	val  modeltype
+        'ghcr.io/lescai-teaching/bigdata-rstudio:1.4.0'}"
 
-	output:
-	path "*.rds", emit: model
-	path "*.pdf", emit: plots
+    input:
+    path dataset
+    path rscript
+    val modeltype
 
-	script:
-	"""
+    output:
+    path '*.rds', emit: model
+    path '*.pdf', emit: plots
+
+    script:
+    """
     Rscript $rscript \
-	$dataset \
-	${task.cpus} \
-	$modeltype
-	"""
-
+    $dataset \
+    ${task.cpus} \
+    $modeltype
+    """
 }

--- a/L34_cloud_nextflow/setup_code/nextflow_environment.yml
+++ b/L34_cloud_nextflow/setup_code/nextflow_environment.yml
@@ -3,7 +3,7 @@ channels:
     - bioconda
     - conda-forge
 dependencies:
-    - nextflow=25.04.2
-    - nf-core
-    - python
-    - nf-test
+    - nextflow=25.10.4
+    - nf-core=3.5.2
+    - python=3.11
+    - nf-test=0.9.3


### PR DESCRIPTION
### Motivation

- Standardize and modernize the course Nextflow examples to consistent DSL2 `workflow` structure and channel usage for clarity and compatibility. 
- Normalize process definitions by adding explicit `script:` blocks and consistent quoting/whitespace to avoid subtle runtime issues. 
- Parameterize compute resources and update environment tool versions to recent releases for reproducible execution.

### Description

- Wrap many scripts in `workflow {}` blocks and declare channel variables with `def` while replacing `Channel` API calls with the lowercase `channel` and methods like `channel.of`, `channel.fromPath`, `channel.fromList`, and `channel.value`.
- Add or normalize `script:` sections in processes, tidy quoting/whitespace, and standardize `output`/`input`/`path`/`val` declarations across modules and examples.
- Introduce and propagate `params.max_cpus` and `params.max_memory` and apply them with `cpus params.max_cpus` and `memory params.max_memory`, update `publishDir` and `container` expressions to a consistent format, and use dynamic publish paths for model runs.
- Update environment YAMLs to use newer tool versions (`nextflow=25.10.4`, `nf-core=3.5.2`, `python=3.11`, `nf-test=0.9.3`) and apply similar refactors across labs L26 through L34 to keep examples consistent.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e5f689d488833188bb2d0e2c55de62)